### PR TITLE
Allow building on stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/davesque/blake2b-py"
 description = "Blake2b hashing in Rust with Python bindings."
 
 [dependencies]
-pyo3 = { version = "~0.8.2", features = ["extension-module"] }
+pyo3 = { version = "~0.15", features = ["extension-module"] }
 
 [dev-dependencies]
 hex = "~0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["maturin"]
+requires = ["maturin>=0.12,<0.13"]
 build-backend = "maturin"

--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -204,8 +204,8 @@ pub fn F(
     ];
 
     let mut result = [0u8; 64];
-    for (i, word_bytes) in result_words.into_iter().enumerate() {
-        for (j, x) in word_bytes.into_iter().enumerate() {
+    for (i, word_bytes) in result_words.iter().enumerate() {
+        for (j, x) in word_bytes.iter().enumerate() {
             result[i * 8 + j] = *x;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(test)]
+#![cfg_attr(
+    test,
+    feature(test)
+)]
 
 mod blake2b;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod blake2b;
 
-use pyo3::exceptions::ValueError;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::wrap_pyfunction;
@@ -29,7 +29,7 @@ fn decode_parameters(input: Vec<u8>) -> PyResult<CompressArgs> {
     let result = blake2b::decode_parameters(&input);
 
     match result {
-        Err(msg) => Err(ValueError::py_err(msg)),
+        Err(msg) => Err(PyValueError::new_err(msg)),
         Ok(args) => {
             let (rounds, state, block, offsets, flag) = args;
             Ok((
@@ -120,7 +120,7 @@ fn compress(
     );
 
     match result {
-        Err(msg) => Err(ValueError::py_err(msg)),
+        Err(msg) => Err(PyValueError::new_err(msg)),
         Ok(ok) => Ok(PyBytes::new(py, &ok).into()),
     }
 }
@@ -150,7 +150,7 @@ fn decode_and_compress(py: Python, input: Vec<u8>) -> PyResult<PyObject> {
     let result = _decode_and_compress(input);
 
     match result {
-        Err(msg) => Err(ValueError::py_err(msg)),
+        Err(msg) => Err(PyValueError::new_err(msg)),
         Ok(ok) => Ok(PyBytes::new(py, &ok).into()),
     }
 }


### PR DESCRIPTION
This PR is only a rebase of PR #9. It allows to build blake2b-py using stable Rust toolchain instead of the nightly toolchain.
The main change is that it only enable feature(test) when testing, so building can be done on stable rust toolchain.