### PR TITLE
Gitignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .tox
+venv*


### PR DESCRIPTION
venv files weren't included in the `.gitignore` file, so added that.