### PR TITLE
Remove --sdist flag from maturin publish command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,4 +124,4 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI }}
-        run: maturin publish --sdist --username __token__ --interpreter python
+        run: maturin publish --username __token__ --interpreter python


### PR DESCRIPTION
The release failed on this line. I tested this command with test pypi and everything seemed to work. The `tar.gz` got uploaded as well as the `.whl`.